### PR TITLE
Use search_type=scroll instead of scan

### DIFF
--- a/elastic-scala-httpclient/src/main/scala/jp/co/bizreach/elasticsearch4s/AsyncESClient.scala
+++ b/elastic-scala-httpclient/src/main/scala/jp/co/bizreach/elasticsearch4s/AsyncESClient.scala
@@ -255,7 +255,7 @@ class AsyncESClient(queryClient: AbstractClient, httpClient: AsyncHttpClient, ur
 
   def scrollAsync[T, R](config: ESConfig)(f: SearchRequestBuilder => Unit)(p: (String, T) => R)(implicit c1: ClassTag[T], c2: ClassTag[R]): Future[Stream[R]] = {
     def scroll0[R](init: Boolean, searchUrl: String, body: String, stream: Stream[R], invoker: (String, Map[String, Any]) => R): Future[Stream[R]] = {
-      val future = HttpUtils.postAsync(httpClient, searchUrl + "?scroll=5m" + (if(init) "&search_type=scan" else ""), body)
+      val future = HttpUtils.postAsync(httpClient, searchUrl + "?scroll=5m&sort=_doc", body)
       future.flatMap { resultJson =>
         val map = JsonUtils.deserialize[Map[String, Any]](resultJson)
         if(map.get("error").isDefined){
@@ -284,7 +284,7 @@ class AsyncESClient(queryClient: AbstractClient, httpClient: AsyncHttpClient, ur
 
   def scrollChunkAsync[T, R](config: ESConfig)(f: SearchRequestBuilder => Unit)(p: (Seq[(String, T)]) => R)(implicit c1: ClassTag[T], c2: ClassTag[R]): Future[Stream[R]] = {
     def scroll0[R](init: Boolean, searchUrl: String, body: String, stream: Stream[R], invoker: (Seq[(String, Map[String, Any])]) => R): Future[Stream[R]] = {
-      val future = HttpUtils.postAsync(httpClient, searchUrl + "?scroll=5m" + (if(init) "&search_type=scan" else ""), body)
+      val future = HttpUtils.postAsync(httpClient, searchUrl + "?scroll=5m&sort=_doc", body)
       future.flatMap { resultJson =>
         val map = JsonUtils.deserialize[Map[String, Any]](resultJson)
         if(map.get("error").isDefined){

--- a/elastic-scala-httpclient/src/main/scala/jp/co/bizreach/elasticsearch4s/ESClient.scala
+++ b/elastic-scala-httpclient/src/main/scala/jp/co/bizreach/elasticsearch4s/ESClient.scala
@@ -267,7 +267,7 @@ class ESClient(httpClient: AsyncHttpClient, url: String, deleteByQueryIsAvailabl
   def scroll[T, R](config: ESConfig)(f: SearchRequestBuilder => Unit)(p: (String, T) => R)(implicit c1: ClassTag[T], c2: ClassTag[R]): Stream[R] = {
     @tailrec
     def scroll0[R](init: Boolean, searchUrl: String, body: String, stream: Stream[R], invoker: (String, Map[String, Any]) => R): Stream[R] = {
-      val resultJson = HttpUtils.post(httpClient, searchUrl + "?scroll=5m" + (if(init) "&search_type=scan" else ""), body)
+      val resultJson = HttpUtils.post(httpClient, searchUrl + "?scroll=5m&sort=_doc", body)
       val map = JsonUtils.deserialize[Map[String, Any]](resultJson)
       if(map.get("error").isDefined){
         throw new RuntimeException(map("error").toString)
@@ -295,7 +295,7 @@ class ESClient(httpClient: AsyncHttpClient, url: String, deleteByQueryIsAvailabl
   def scrollChunk[T, R](config: ESConfig)(f: SearchRequestBuilder => Unit)(p: (Seq[(String, T)]) => R)(implicit c1: ClassTag[T], c2: ClassTag[R]): Stream[R] = {
     @tailrec
     def scroll0[R](init: Boolean, searchUrl: String, body: String, stream: Stream[R], invoker: (Seq[(String, Map[String, Any])]) => R): Stream[R] = {
-      val resultJson = HttpUtils.post(httpClient, searchUrl + "?scroll=5m" + (if(init) "&search_type=scan" else ""), body)
+      val resultJson = HttpUtils.post(httpClient, searchUrl + "?scroll=5m&sort=_doc", body)
       val map = JsonUtils.deserialize[Map[String, Any]](resultJson)
       if(map.get("error").isDefined){
         throw new RuntimeException(map("error").toString)


### PR DESCRIPTION
Query parameter `search_type=scan` is now deprecated and does not provide any benefits over a regular scroll request sorted by _doc, so use `search_type=scroll&sort=_doc` .

https://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-request-scroll.html#search-request-scroll