### PR TITLE
fix search url of async es client

### DIFF
--- a/elastic-scala-httpclient/src/main/scala/jp/co/bizreach/elasticsearch4s/AsyncESClient.scala
+++ b/elastic-scala-httpclient/src/main/scala/jp/co/bizreach/elasticsearch4s/AsyncESClient.scala
@@ -54,7 +54,7 @@ class AsyncESClient(queryClient: AbstractClient, httpClient: AsyncHttpClient, ur
     f(searcher)
     logger.debug(s"searchRequest:${searcher.toString}")
 
-    val future = HttpUtils.postAsync(httpClient, config.preferenceUrl(url, "/_search"), searcher.toString)
+    val future = HttpUtils.postAsync(httpClient, config.preferenceUrl(url, "_search"), searcher.toString)
     future.map { resultJson =>
       val map = JsonUtils.deserialize[Map[String, Any]](resultJson)
       map.get("error").map { case message: String => Left(map) }.getOrElse(Right(map))


### PR DESCRIPTION
I fixed AsyncESClient's search url. I think that it causes 400 error. Blocking ESClient seems to be correct. https://github.com/bizreach/elastic-scala-httpclient/blob/master/elastic-scala-httpclient/src/main/scala/jp/co/bizreach/elasticsearch4s/ESClient.scala#L85